### PR TITLE
Acréscimo de apoiador, correção de links

### DIFF
--- a/about.md
+++ b/about.md
@@ -10,15 +10,17 @@ Grupo para unir os desenvolvedores e usuários de Python da região do ABC e do 
 * Padaria Bella Vieira
 * [CNCZumaq] [cnc-zumaq]
 * [UFABC] [ufabc]
-* [FATEC-Sao Caetano] [fatec-scs]
+* [FATEC São Caetano do Sul] [fatec-scs]
+* [FATEC Mauá] [fatec-maua]
 
 # Fique por dentro
 
-* [Telegram](telegram)
-* [Tweets](tweets)
+* [Telegram] [telegram]
+* [Tweets] [tweets]
 
 [cnc-zumaq]: https://www.produtos.cnczumaq.com/
 [ufabc]: http://www.ufabc.edu.br/
 [fatec-scs]: https://www.fatecsaocaetano.edu.br/
+[fatec-maua]: http://www.fatecmaua.com.br/
 [telegram]: https://t.me/grupyabc
 [tweets]: https://twitter.com/search?q=grupy-abc


### PR DESCRIPTION
Corrigidos os links para Telegram e Tweets e acréscimo da FATEC Mauá entre os apoiadores.